### PR TITLE
Fix code scanning alert no. 2: Implicit narrowing conversion in compound assignment

### DIFF
--- a/src/main/java/org/yaml/snakeyaml/constructor/SafeConstructor.java
+++ b/src/main/java/org/yaml/snakeyaml/constructor/SafeConstructor.java
@@ -269,7 +269,7 @@ public class SafeConstructor extends BaseConstructor {
       } else if (value.indexOf(':') != -1) {
         String[] digits = value.split(":");
         int bes = 1;
-        int val = 0;
+        long val = 0;
         for (int i = 0, j = digits.length; i < j; i++) {
           val += Long.parseLong(digits[j - i - 1]) * bes;
           bes *= 60;


### PR DESCRIPTION
Fixes [https://github.com/FurryPlayPlace/CottonFramework/security/code-scanning/2](https://github.com/FurryPlayPlace/CottonFramework/security/code-scanning/2)

To fix the problem, we need to ensure that the type of the left-hand side of the compound assignment statement is at least as wide as the type of the right-hand side. In this case, we should change the type of `val` from `int` to `long` to match the type of the expression being assigned to it. This will prevent any implicit narrowing conversion and avoid potential information loss or overflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
